### PR TITLE
Added result scenes and success collection behavior

### DIFF
--- a/src/main/java/CollectionController.java
+++ b/src/main/java/CollectionController.java
@@ -47,14 +47,19 @@ public class CollectionController {
     public void initialize() {
         DatabaseManager db = DatabaseManager.getInstance();
 
-        int userId = db.getUserId("test user 1");
+        GameManager gm = GameManager.getInstance();
 
-        if (userId == -1) {
-            userId = db.insertUser("test user 1", "password");
-            int wordId = db.insertWord("banana", 2);
-            db.addCollectedWord(userId, wordId, 0);
+        int userId = gm.getUserId();
+
+        if (userId <= 0 && gm.getUser() != null) {
+            userId = db.getUserId(gm.getUser());
+            gm.setUserId(userId);
         }
-        GameManager.getInstance().setUserId(userId);
+
+        if (userId == -1 || userId == 0) {
+            messageLabel.setText("No logged-in user found.");
+            return;
+        }
 
         List<String> words = db.getCollectedWordsForUser(userId);
         wordListView.getItems().setAll(words);
@@ -72,7 +77,7 @@ public class CollectionController {
             messageLabel.setText("Choose a word before sending an attack.");
         } else {
             messageLabel.setText("Attack selected with word: " + selectedWord);
-            GameManager.getInstance().setSendAttackWord(db.getUserId(selectedWord));
+            GameManager.getInstance().setSendAttackWord(db.getWordId(selectedWord));
             SceneManager.getInstance().navigateTo(SceneType.ATTACKING);
         }
     }

--- a/src/main/java/DatabaseManager.java
+++ b/src/main/java/DatabaseManager.java
@@ -190,6 +190,17 @@ public class DatabaseManager {
 		return 0;
 	}
 
+	public void updateUserScore(int id, int scoreChange) {
+		String sql = "UPDATE Users SET score = score + ? WHERE id = ?";
+		try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+			pstmt.setInt(1, scoreChange);
+			pstmt.setInt(2, id);
+			pstmt.executeUpdate();
+		} catch (SQLException e) {
+			System.err.println("updateUserScore failed: " + e.getMessage());
+		}
+	}
+
 	public void deleteUser(int id) {
 		String sql = "DELETE FROM Users WHERE id = ?";
 		try(PreparedStatement pstmt = connection.prepareStatement(sql)) {

--- a/src/main/java/FailureAttackedController.java
+++ b/src/main/java/FailureAttackedController.java
@@ -1,0 +1,110 @@
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class FailureAttackedController {
+    @FXML
+    private Label wordLabel;
+
+    @FXML
+    private Label scoreLabel;
+
+    @FXML
+    private Label attackWordsLabel;
+
+    public Scene buildScene() {
+        URL fxmlURL = getClass().getResource("/FailureAttacked.fxml");
+        FXMLLoader loader = new FXMLLoader(fxmlURL);
+
+        try {
+            Parent root = loader.load();
+            return new Scene(root, 640, 480);
+        } catch (IOException e) {
+            System.err.println("FailureAttackedController buildScene failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @FXML
+    public void initialize() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        wordLabel.setText("Main word was: " + gm.getRandomWord());
+        scoreLabel.setText("Score change: " + gm.getEarnedScore());
+        attackWordsLabel.setText("Attack words: " + getAttackWordsText());
+
+        int userId = getCurrentUserId();
+        if (userId != -1) {
+            db.updateUserScore(userId, gm.getEarnedScore());
+        }
+
+        deleteCompletedAttacks();
+    }
+
+    public void continueToMenu() {
+        SceneManager.getInstance().navigateTo(SceneType.MAIN);
+    }
+
+    private String getAttackWordsText() {
+        DatabaseManager db = DatabaseManager.getInstance();
+        GameManager gm = GameManager.getInstance();
+
+        StringBuilder result = new StringBuilder();
+
+        appendAttackWord(result, db, gm.getAttackWordID0());
+        appendAttackWord(result, db, gm.getAttackWordID1());
+        appendAttackWord(result, db, gm.getAttackWordID2());
+
+        if (result.isEmpty()) {
+            return "none";
+        }
+
+        return result.toString();
+    }
+
+    private void appendAttackWord(StringBuilder result, DatabaseManager db, int attackId) {
+        if (attackId == -1) {
+            return;
+        }
+
+        int wordId = db.getAttackWord(attackId);
+        String word = db.getWordText(wordId);
+
+        if (word != null && !word.isBlank()) {
+            if (!result.isEmpty()) {
+                result.append(", ");
+            }
+            result.append(word);
+        }
+    }
+
+    private void deleteCompletedAttacks() {
+        DatabaseManager db = DatabaseManager.getInstance();
+        GameManager gm = GameManager.getInstance();
+
+        if (gm.getAttackWordID0() != -1) db.deleteAttack(gm.getAttackWordID0());
+        if (gm.getAttackWordID1() != -1) db.deleteAttack(gm.getAttackWordID1());
+        if (gm.getAttackWordID2() != -1) db.deleteAttack(gm.getAttackWordID2());
+    }
+
+    private int getCurrentUserId() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        if (gm.getUserId() > 0) {
+            return gm.getUserId();
+        }
+
+        if (gm.getUser() != null) {
+            return db.getUserId(gm.getUser());
+        }
+
+        return -1;
+    }
+}

--- a/src/main/java/LogInController.java
+++ b/src/main/java/LogInController.java
@@ -48,6 +48,7 @@ public class LogInController {
                 LogInMessage.setText("Incorrect Username or Password");
             }else{
                 GameManager.getInstance().setUser(Username);
+                GameManager.getInstance().setUserId(userID);
                 SceneManager.getInstance().navigateTo(SceneType.PROFILE);
             }
 

--- a/src/main/java/SceneFactory.java
+++ b/src/main/java/SceneFactory.java
@@ -25,8 +25,8 @@ public class SceneFactory {
 			case LEADERBOARD -> new LeaderboardController().buildScene();
 			case SIGN_UP -> new SignUpController().buildScene();
 			case PLAY_ATTACKED -> new PlayAttackedController().buildScene();
-			case FAILURE_ATTACKED -> null;
-			case SUCCESS_ATTACKED -> null;
+			case FAILURE_ATTACKED -> new FailureAttackedController().buildScene();
+			case SUCCESS_ATTACKED -> new SuccessAttackedController().buildScene();
 		};
 	}
 

--- a/src/main/java/SceneManager.java
+++ b/src/main/java/SceneManager.java
@@ -29,13 +29,24 @@ public class SceneManager {
 
     public void navigateTo(SceneType type) {
         Scene scene;
-        if(type==SceneType.PLAY || type==SceneType.PLAY_ATTACKED || type==SceneType.PROFILE) { //put SceneTypes in here if they shouldn't get cached
+
+        // scenes that should refresh every time
+        if(type == SceneType.PLAY
+                || type == SceneType.PLAY_ATTACKED
+                || type == SceneType.PROFILE
+                || type == SceneType.COLLECTION
+                || type == SceneType.SUCCESS
+                || type == SceneType.FAILURE
+                || type == SceneType.SUCCESS_ATTACKED
+                || type == SceneType.FAILURE_ATTACKED) {
+
             scene = SceneFactory.create(type, stage);
         }
         else {
             scene = cache.computeIfAbsent(type,
                     t -> SceneFactory.create(t, stage));
         }
+
         stage.setScene(scene);
     }
 }

--- a/src/main/java/SignUpController.java
+++ b/src/main/java/SignUpController.java
@@ -48,6 +48,7 @@ public class SignUpController {
                     label.setText("User already exist");
                 } else {
                     GameManager.getInstance().setUser(username);
+                    GameManager.getInstance().setUserId(createUser);
                     SceneManager.getInstance().navigateTo(SceneType.PROFILE);
                 }
             }else{

--- a/src/main/java/SuccessAttackedController.java
+++ b/src/main/java/SuccessAttackedController.java
@@ -1,0 +1,110 @@
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class SuccessAttackedController {
+    @FXML
+    private Label wordLabel;
+
+    @FXML
+    private Label scoreLabel;
+
+    @FXML
+    private Label attackWordsLabel;
+
+    public Scene buildScene() {
+        URL fxmlURL = getClass().getResource("/SuccessAttacked.fxml");
+        FXMLLoader loader = new FXMLLoader(fxmlURL);
+
+        try {
+            Parent root = loader.load();
+            return new Scene(root, 640, 480);
+        } catch (IOException e) {
+            System.err.println("SuccessAttackedController buildScene failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @FXML
+    public void initialize() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        wordLabel.setText("Main word was: " + gm.getRandomWord());
+        scoreLabel.setText("Score change: +" + gm.getEarnedScore());
+        attackWordsLabel.setText("Attack words: " + getAttackWordsText());
+
+        int userId = getCurrentUserId();
+        if (userId != -1) {
+            db.updateUserScore(userId, gm.getEarnedScore());
+        }
+
+        deleteCompletedAttacks();
+    }
+
+    public void continueToMenu() {
+        SceneManager.getInstance().navigateTo(SceneType.MAIN);
+    }
+
+    private String getAttackWordsText() {
+        DatabaseManager db = DatabaseManager.getInstance();
+        GameManager gm = GameManager.getInstance();
+
+        StringBuilder result = new StringBuilder();
+
+        appendAttackWord(result, db, gm.getAttackWordID0());
+        appendAttackWord(result, db, gm.getAttackWordID1());
+        appendAttackWord(result, db, gm.getAttackWordID2());
+
+        if (result.isEmpty()) {
+            return "none";
+        }
+
+        return result.toString();
+    }
+
+    private void appendAttackWord(StringBuilder result, DatabaseManager db, int attackId) {
+        if (attackId == -1) {
+            return;
+        }
+
+        int wordId = db.getAttackWord(attackId);
+        String word = db.getWordText(wordId);
+
+        if (word != null && !word.isBlank()) {
+            if (!result.isEmpty()) {
+                result.append(", ");
+            }
+            result.append(word);
+        }
+    }
+
+    private void deleteCompletedAttacks() {
+        DatabaseManager db = DatabaseManager.getInstance();
+        GameManager gm = GameManager.getInstance();
+
+        if (gm.getAttackWordID0() != -1) db.deleteAttack(gm.getAttackWordID0());
+        if (gm.getAttackWordID1() != -1) db.deleteAttack(gm.getAttackWordID1());
+        if (gm.getAttackWordID2() != -1) db.deleteAttack(gm.getAttackWordID2());
+    }
+
+    private int getCurrentUserId() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        if (gm.getUserId() > 0) {
+            return gm.getUserId();
+        }
+
+        if (gm.getUser() != null) {
+            return db.getUserId(gm.getUser());
+        }
+
+        return -1;
+    }
+}

--- a/src/main/java/SuccessController.java
+++ b/src/main/java/SuccessController.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Label;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 
 /**
  * SuccessController.java
@@ -25,37 +26,88 @@ public class SuccessController {
     @FXML
     private Label scoreLabel;
 
+    @FXML
+    private Label messageLabel;
+
     public Scene buildScene() {
         URL fxmlURL = getClass().getResource("/Success.fxml");
         FXMLLoader loader = new FXMLLoader(fxmlURL);
-        Scene scene = null;
 
         try {
             Parent root = loader.load();
-            scene = new Scene(root, 640, 480);
+            return new Scene(root, 640, 480);
         } catch (IOException e) {
             System.err.println("SuccessController buildScene failed: " + e.getMessage());
+            return null;
         }
-
-        return scene;
     }
 
     @FXML
     public void initialize() {
         GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
 
         String word = gm.getRandomWord();
+        int scoreChange = gm.getEarnedScore();
 
-        if (word == null || word.isBlank()) {
-            wordLabel.setText("Word was: unknown");
-        } else {
-            wordLabel.setText("Word was: " + word);
+        wordLabel.setText("Word was: " + word);
+        scoreLabel.setText("Score change: +" + scoreChange);
+
+        int userId = getCurrentUserId();
+        if (userId != -1) {
+            db.updateUserScore(userId, scoreChange);
+        }
+    }
+
+    public void collectWord() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        int userId = getCurrentUserId();
+        String word = gm.getRandomWord();
+
+        if (userId == -1 || word == null || word.isBlank()) {
+            messageLabel.setText("Could not collect word.");
+            return;
         }
 
-        scoreLabel.setText("Score change: +" + gm.getEarnedScore());
+        List<String> collected = db.getCollectedWordsForUser(userId);
+
+        if (collected.contains(word)) {
+            messageLabel.setText("Word already collected.");
+            return;
+        }
+
+        if (collected.size() >= 3) {
+            messageLabel.setText("Collection is full.");
+            return;
+        }
+
+        int wordId = db.getWordId(word);
+        if (wordId == -1) {
+            wordId = db.insertWord(word, 2);
+        }
+
+        db.addCollectedWord(userId, wordId, collected.size());
+        messageLabel.setText("Word collected!");
     }
 
     public void continueToMenu() {
         SceneManager.getInstance().navigateTo(SceneType.MAIN);
+    }
+
+    private int getCurrentUserId() {
+        GameManager gm = GameManager.getInstance();
+        DatabaseManager db = DatabaseManager.getInstance();
+
+        if (gm.getUserId() > 0) {
+            return gm.getUserId();
+        }
+
+        if (gm.getUser() != null) {
+            return db.getUserId(gm.getUser());
+        }
+
+        return -1;
     }
 }

--- a/src/main/resources/FailureAttacked.fxml
+++ b/src/main/resources/FailureAttacked.fxml
@@ -10,28 +10,23 @@
       prefWidth="640.0"
       xmlns="http://javafx.com/javafx/17.0.12"
       xmlns:fx="http://javafx.com/fxml/1"
-      fx:controller="SuccessController">
+      fx:controller="FailureAttackedController">
 
     <children>
-        <Label text="Success!"
+        <Label text="Attack Successful..."
                style="-fx-font-size: 32px; -fx-font-weight: bold;" />
 
         <Label fx:id="wordLabel"
-               text="Word was:"
+               text="Main word was:"
                style="-fx-font-size: 20px;" />
+
+        <Label fx:id="attackWordsLabel"
+               text="Attack words:"
+               style="-fx-font-size: 18px;" />
 
         <Label fx:id="scoreLabel"
                text="Score change:"
                style="-fx-font-size: 18px;" />
-
-        <Button text="Collect Word"
-                prefWidth="180.0"
-                prefHeight="40.0"
-                onAction="#collectWord" />
-
-        <Label fx:id="messageLabel"
-               text=""
-               style="-fx-font-size: 14px;" />
 
         <Button text="Continue"
                 prefWidth="180.0"

--- a/src/main/resources/SuccessAttacked.fxml
+++ b/src/main/resources/SuccessAttacked.fxml
@@ -10,28 +10,23 @@
       prefWidth="640.0"
       xmlns="http://javafx.com/javafx/17.0.12"
       xmlns:fx="http://javafx.com/fxml/1"
-      fx:controller="SuccessController">
+      fx:controller="SuccessAttackedController">
 
     <children>
-        <Label text="Success!"
+        <Label text="Attack Survived!"
                style="-fx-font-size: 32px; -fx-font-weight: bold;" />
 
         <Label fx:id="wordLabel"
-               text="Word was:"
+               text="Main word was:"
                style="-fx-font-size: 20px;" />
+
+        <Label fx:id="attackWordsLabel"
+               text="Attack words:"
+               style="-fx-font-size: 18px;" />
 
         <Label fx:id="scoreLabel"
                text="Score change:"
                style="-fx-font-size: 18px;" />
-
-        <Button text="Collect Word"
-                prefWidth="180.0"
-                prefHeight="40.0"
-                onAction="#collectWord" />
-
-        <Label fx:id="messageLabel"
-               text=""
-               style="-fx-font-size: 14px;" />
 
         <Button text="Continue"
                 prefWidth="180.0"


### PR DESCRIPTION
Implemented remaining result scene functionality and success collection behavior.

## Changes
- Added SUCCESS_ATTACKED scene/controller
- Added FAILURE_ATTACKED scene/controller
- Added score updating from success scenes
- Added word collection functionality
- Prevented duplicate collected words
- Updated SceneManager non-cached scenes
- Fixed collection scene using logged-in user